### PR TITLE
LE-56: Requests for the Types should be cached

### DIFF
--- a/src/components/markers/markers.spec.ts
+++ b/src/components/markers/markers.spec.ts
@@ -8,7 +8,8 @@ let toTest: MarkersComponent;
 /**
  * Created by jett on 9/3/17.
  */
-describe("SessionTokenService Service", () => {
+describe("Markers", () => {
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -21,7 +22,6 @@ describe("SessionTokenService Service", () => {
     }).compileComponents();
 
     toTest = TestBed.get(MarkersComponent);
-
   });
 
   it("should be defined", () => {

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -1,6 +1,5 @@
 import {Component} from "@angular/core";
 import {MapComponent} from "../../components/map/map";
-import {NavController} from "ionic-angular";
 import {locationServiceProvider} from "../../providers/resources/location/location.service.provider";
 import {LocationService} from "../../providers/resources/location/location.service";
 import {GeoLocComponent} from "../../components/geo-loc/geo-loc";
@@ -22,7 +21,6 @@ export class HomePage {
   locationMap = {};
 
   constructor(
-    public navCtrl: NavController,
     public mapComponent: MapComponent,
     public locationService: LocationService,
     public locationTypeService: LocationTypeService,
@@ -63,6 +61,23 @@ export class HomePage {
   }
 
   ngOnInit(): void {
+    this.awaitAppInitialization();
+  }
+
+  ngOnDestroy(): void {
+    this.mapComponent.closeMap();
+  }
+
+  /**
+   * Sequences a number of components and services needed prior to
+   * displaying the initial page.
+   */
+  awaitAppInitialization(): void {
+    this.initializeCaches();
+    this.initializePositionSource();
+  }
+
+  initializePositionSource(): void {
     /* Sort out how we obtain our positioning. */
     let positionObservable = this.geoLoc.getPositionWatch();
 
@@ -78,8 +93,8 @@ export class HomePage {
     );
   }
 
-  ngOnDestroy(): void {
-    this.mapComponent.closeMap();
+  initializeCaches(): void {
+    this.locationTypeService.initializeCache();
   }
 
 }

--- a/src/pages/loc-edit/loc-edit.ts
+++ b/src/pages/loc-edit/loc-edit.ts
@@ -42,16 +42,12 @@ export class LocEditPage {
     this.editSegment = this.editSegments[navParams.get("tabId")];
     this.location = navParams.get("location");
 
-    this.locationTypeService.allLocationTypes({}).subscribe(
-      (locationTypes) => {
-        locationTypes.forEach(
-          (locationType, key) => {
-            this.locTypes.push(
-              {
-                value: locationType.id,
-                text: locationType.name
-              }
-            );
+    this.locationTypeService.allLocationTypes().forEach(
+      (locationType) => {
+        this.locTypes.push(
+          {
+            value: locationType.id,
+            text: locationType.name
           }
         );
       }

--- a/src/providers/resources/README.md
+++ b/src/providers/resources/README.md
@@ -61,3 +61,23 @@ collision).
 - Currently, more than one class is defined in the location.ts file; 
 want to break these out.
 
+
+# Testing
+Resources fall under the category of "Services". Along with Pipes, Services are generally
+tested in "isolation" instead of part of a TestBed.
+
+I mention Injectors below because I didn't have another place to put these right now.
+
+## Injectors
+
+    const injector = ReflectiveInjector.resolveAndCreate([
+      locationTypeServiceProvider
+    ]);
+    
+## Using the Injector
+
+      beforeEach(() => {
+        toTest = new LocationTypeService(
+          injector.get(LOCATION_TYPE_REST)
+        );
+      });

--- a/src/providers/resources/badge/badge.service.provider.ts
+++ b/src/providers/resources/badge/badge.service.provider.ts
@@ -1,8 +1,8 @@
 import {SessionTokenService} from "../../session-token/session-token.service";
-import {OpaqueToken} from "@angular/core";
+import {InjectionToken} from "@angular/core";
 import {Restangular} from "ngx-restangular/dist/esm/src";
 
-export const BADGES_REST = new OpaqueToken('BadgeResource');
+export const BADGES_REST = new InjectionToken<string>('BadgeResource');
 
 function RestFactory(
   restangular: Restangular,

--- a/src/providers/resources/location/location.service.provider.ts
+++ b/src/providers/resources/location/location.service.provider.ts
@@ -1,8 +1,8 @@
-import {OpaqueToken} from "@angular/core";
+import {InjectionToken} from "@angular/core";
 import {Resource} from "../resource";
 import {Restangular} from "ngx-restangular";
 
-export const LOCATION_REST = new OpaqueToken('LocationResource');
+export const LOCATION_REST = new InjectionToken<string>('LocationResource');
 
 /* Resource providing Nearest Location instances suitable for edit. */
 const NEAREST =

--- a/src/providers/resources/loctype/loctype.service.provider.ts
+++ b/src/providers/resources/loctype/loctype.service.provider.ts
@@ -1,8 +1,8 @@
 import {Restangular} from "ngx-restangular";
-import {OpaqueToken} from "@angular/core";
+import {InjectionToken} from "@angular/core";
 import {Resource} from "../resource";
 
-export const LOCATION_TYPE_REST = new OpaqueToken('LocationTypeResource');
+export const LOCATION_TYPE_REST = new InjectionToken<string>('LocationTypeResource');
 
 const TYPES =
   {

--- a/src/providers/resources/loctype/loctype.spec.ts
+++ b/src/providers/resources/loctype/loctype.spec.ts
@@ -1,0 +1,83 @@
+import {LocationTypeService} from "./loctype.service";
+import {Subject} from "rxjs/Subject";
+import LocationType = clueRide.LocationType;
+import any = jasmine.any;
+/**
+ * Created by jett on 10/29/17.
+ */
+
+let toTest: LocationTypeService;
+const resourceSubject: Subject<Array<LocationType>> = new Subject();
+
+let mockResource = {
+  mock: true,
+  types: function (any) {
+    return resourceSubject.asObservable();
+  }
+};
+
+const locType: LocationType = {
+    id: 6,
+    name: "Beverages to Go",
+    description: "Indescribable",
+    icon: "coffee"
+  };
+
+let types: Array<LocationType>;
+
+describe("Location Type Service", () => {
+
+  beforeEach(() => {
+    resourceSubject.next([locType]);
+    toTest = new LocationTypeService(
+      mockResource
+    );
+  });
+
+  it("should be defined", () => {
+    expect(toTest).toBeDefined();
+  });
+
+  describe("hits cache when appropriate", () => {
+
+    it("should invoke the REST API on the first call", () => {
+      /* train mocks */
+      spyOn(mockResource, 'types').and.returnValue(resourceSubject.asObservable());
+
+      /* make calls */
+      toTest.initializeCache();
+      types = toTest.allLocationTypes();
+
+      /* verify results */
+      expect(mockResource.types).toHaveBeenCalled();
+    });
+
+    it("should invoke the cache -- and not REST API -- on subsequent call", () => {
+      /* train mocks */
+      spyOn(mockResource, 'types').and.returnValue(resourceSubject.asObservable());
+
+      /* make calls */
+      toTest.initializeCache();
+      types = toTest.allLocationTypes();
+
+      /* verify results */
+      expect(mockResource.types).not.toHaveBeenCalled();
+    });
+
+  });
+
+  describe("Location Types", () => {
+
+    it("should provide Loc Type by ID", () => {
+      let expected: LocationType  = locType;
+      let actual = toTest.getById(locType.id);
+      expect(actual).toBe(expected);
+    });
+
+    it("should return empty value if ID doesn't match", () => {
+      let actual = toTest.getById(-1);
+      expect(actual).toBeFalsy();
+    });
+  })
+
+});

--- a/src/providers/resources/puzzle/puzzle.service.provider.ts
+++ b/src/providers/resources/puzzle/puzzle.service.provider.ts
@@ -1,11 +1,11 @@
-import {OpaqueToken} from "@angular/core";
+import {InjectionToken} from "@angular/core";
 import {Resource} from "../resource";
 import {Restangular} from "ngx-restangular";
 /**
  * Created by jett on 10/24/17.
  */
 
-export const PUZZLE_REST = new OpaqueToken('PuzzleResource');
+export const PUZZLE_REST = new InjectionToken<string>('PuzzleResource');
 
 /* Resource providing list of Puzzles for a given Location (by ID). */
 const BY_LOCATION =


### PR DESCRIPTION
* Creates "isolated" Jasmine spec for the Location Type Service.
  * Decent use of Spy to tell if resource is being invoked.
  * Decent use of Mock to avoid calling into Restangular implementation.
* Replaces obsolete OpaqueToken with InjectionToken for Resources.
* Sets up improved life-cycle management of Cached resources.
  * Avoiding doing too much in our constructors; DI only, init from outside.
  * Explicit calls to initialize make it easier to mock/spy/test and
    integrate into rest of app.
* Records use of Injector in the README.md file.