### PR TITLE
LE-82 Markers have problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "ngx-restangular": "1.0.13",
         "rxjs": "5.5.2",
         "sw-toolbox": "3.6.0",
+        "ws": "^3.3.2",
         "zone.js": "0.8.10"
     },
     "devDependencies": {


### PR DESCRIPTION
This is not the solution to the problem, but while testing out this
feature, I ran into the problem where "ionic serve" would abort when
the page was refreshed.  The solution was to rollback the version of
the 'ws' module to 3.3.2.

The actual solution was to follow the README.md in the markers package:
"Copy leaflet.awesome-marker's CSS to a SCSS file."