### PR TITLE
LE-85 Remove namespaces

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import {LocEditPageModule} from "../pages/loc-edit/loc-edit.module";
 import {MapComponentModule} from "../components/map/map.module";
 import {DeviceGeoLocService} from "../providers/device-geo-loc/device-geo-loc.service";
 import {MoveStartService} from "../providers/move-start/move-start";
+import {LatLonProvider} from "../providers/lat-lon/lat-lon";
 
 @NgModule({
   declarations: [
@@ -57,6 +58,7 @@ import {MoveStartService} from "../providers/move-start/move-start";
     StatusBar,
     SplashScreen,
     {provide: ErrorHandler, useClass: IonicErrorHandler},
+    LatLonProvider,
   ]
 })
 export class AppModule {}

--- a/src/components/geo-loc/geo-loc.ts
+++ b/src/components/geo-loc/geo-loc.ts
@@ -6,7 +6,7 @@ import {Subject} from "rxjs/Subject";
 import {Restangular} from "ngx-restangular";
 import {DeviceGeoLocService} from "../../providers/device-geo-loc/device-geo-loc.service";
 import {isDefined} from "ionic-angular/util/util";
-import LatLon = clueRide.LatLon;
+import {LatLon} from "../../providers/lat-lon/lat-lon";
 
 function buildGeoPositionFromLatLon(latLon: LatLon): Geoposition {
   return {

--- a/src/components/map/map.ts
+++ b/src/components/map/map.ts
@@ -6,14 +6,15 @@ import {SplashScreen} from "@ionic-native/splash-screen";
 import {Geoposition} from "@ionic-native/geolocation";
 import * as L from "leaflet";
 import {CRMarker} from "../markers/crMarker";
+import {Location} from "../../providers/resources/location/location";
 import {LocEditPage} from "../../pages/loc-edit/loc-edit";
 import {App} from "ionic-angular";
+import {LatLon} from "../../providers/lat-lon/lat-lon";
 import {LatLonComponent} from "../lat-lon/lat-lon";
 import {HeadingComponent} from "../heading/heading";
 import {Observable} from "rxjs/Observable";
 import {MoveStartService} from "../../providers/move-start/move-start";
 import {Subject} from "rxjs/Subject";
-import LatLon = clueRide.LatLon;
 
 /**
  * Generated class for the MapComponent component.
@@ -149,7 +150,7 @@ export class MapComponent {
    * @param iconName string name of the icon to represent the location (based on location type).
    */
   public addLocation(
-    location: clueRide.Location,
+    location: Location,
     iconName: string
   ) {
     MapComponent.locationMap[location.id] = location;
@@ -172,10 +173,10 @@ export class MapComponent {
 
   /**
    * Reads the Location's readiness level to determine which tab to show.
-   * @param {clueRide.Location} loc instance carrying a readinessLevel.
+   * @param {Location} loc instance carrying a readinessLevel.
    * @returns {number} representing an offset from Draft.
    */
-  private static getTabIdForLocation(loc: clueRide.Location) {
+  private static getTabIdForLocation(loc: Location) {
     switch(loc.readinessLevel) {
       case 'FEATURED':
         return 2;

--- a/src/components/markers/crMarker.ts
+++ b/src/components/markers/crMarker.ts
@@ -1,4 +1,5 @@
 import {Marker, MarkerOptions} from "leaflet";
+import {Location} from "../../providers/resources/location/location";
 
 /**
  * Created by jett on 9/8/17.
@@ -9,7 +10,7 @@ export class CRMarker extends Marker {
   locationId: number;
 
   constructor(
-    location: clueRide.Location,
+    location: Location,
     options: MarkerOptions,
   ) {
     super(location.latLon, options);

--- a/src/components/markers/markers.ts
+++ b/src/components/markers/markers.ts
@@ -2,6 +2,7 @@ import {Component, Injectable} from "@angular/core";
 import * as L from "leaflet";
 import "leaflet.awesome-markers/dist/leaflet.awesome-markers";
 import {CRMarker} from "./crMarker";
+import {Location} from "../../providers/resources/location/location";
 import MarkerOptions = L.MarkerOptions;
 
 /**
@@ -54,7 +55,7 @@ export class MarkersComponent {
   }
 
   public getLocationMarker(
-    location: clueRide.Location,
+    location: Location,
     iconName: string
   ): CRMarker {
     let markerOptions: MarkerOptions = {

--- a/src/components/puzzle-list/puzzle-list.ts
+++ b/src/components/puzzle-list/puzzle-list.ts
@@ -5,7 +5,7 @@ import {Component, Injectable, Input} from "@angular/core";
 // tslint:disable-next-line
 import {Restangular} from "ngx-restangular";
 import {ModalController} from "ionic-angular";
-import Puzzle = clueRide.Puzzle;
+import {Puzzle} from "../../providers/resources/puzzle/puzzle";
 @Injectable()
 @Component({
   selector: 'puzzle-list',

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -1,6 +1,7 @@
 import {Component} from "@angular/core";
 import {MapComponent} from "../../components/map/map";
 import {locationServiceProvider} from "../../providers/resources/location/location.service.provider";
+import {Location} from "../../providers/resources/location/location";
 import {LocationService} from "../../providers/resources/location/location.service";
 import {GeoLocComponent} from "../../components/geo-loc/geo-loc";
 import {LocationTypeService} from "../../providers/resources/loctype/loctype.service";
@@ -80,7 +81,7 @@ export class HomePage {
    * them all together.
    * @param location
    */
-  assembleAndAddLocation(location: clueRide.Location) {
+  assembleAndAddLocation(location: Location) {
     let locationType = this.locationTypeService.getById(location.locationTypeId);
     console.log(location.id + ": " + location.name);
     this.mapComponent.addLocation(location, locationType.icon);

--- a/src/pages/image-capture/image-capture.spec.ts
+++ b/src/pages/image-capture/image-capture.spec.ts
@@ -2,6 +2,7 @@ import {ImageCapturePage} from "./image-capture";
 import {TestBed} from "@angular/core/testing";
 import {IonicModule, NavParams} from "ionic-angular";
 import {Camera} from "@ionic-native/camera";
+import {Location} from "../../providers/resources/location/location";
 import {RestangularModule} from "ngx-restangular";
 /**
  * Created by jett on 11/5/17.
@@ -9,7 +10,7 @@ import {RestangularModule} from "ngx-restangular";
 
 let toTest: ImageCapturePage;
 
-const location: clueRide.Location = {
+const location: Location = {
   id: 13,
   nodeId: 13,
   latLon: {

--- a/src/pages/image-capture/image-capture.ts
+++ b/src/pages/image-capture/image-capture.ts
@@ -3,6 +3,7 @@ import {Component} from "@angular/core";
 import {App, IonicPage, NavParams} from "ionic-angular";
 import {ImageService} from "../../providers/resources/image/image.service";
 import {imageServiceProvider} from "../../providers/resources/image/image.service.provider";
+import {Location} from "../../providers/resources/location/location";
 // tslint:disable-next-line
 import {Restangular} from "ngx-restangular";
 
@@ -25,7 +26,7 @@ export class ImageCapturePage {
 
   public base64Image: string;
   public images: Array<any> = [];
-  private location: clueRide.Location;
+  private location: Location;
 
   private cameraOptions: CameraOptions = {
     correctOrientation: true,
@@ -65,8 +66,8 @@ export class ImageCapturePage {
   }
 
   public save() {
-    // What I'd prefer, but the clueRide.Image isn't found anywhere
-    // let image = new clueRide.Image();
+    // What I'd prefer, but the Image isn't found anywhere
+    // let image = new Image();
     // image.populateFromLocation(this.location);
     // image.addImageData(this.images[0].src);
 

--- a/src/pages/loc-edit/loc-edit.ts
+++ b/src/pages/loc-edit/loc-edit.ts
@@ -1,5 +1,6 @@
 import {Component} from "@angular/core";
 import {AlertController, App, IonicPage, NavParams} from "ionic-angular";
+import {Location} from "../../providers/resources/location/location";
 import {LocationService} from "../../providers/resources/location/location.service";
 import {locationServiceProvider} from "../../providers/resources/location/location.service.provider";
 import {LocationTypeService} from "../../providers/resources/loctype/loctype.service";
@@ -28,7 +29,7 @@ import {Restangular} from "ngx-restangular";
 export class LocEditPage {
 
   editSegment: string;
-  location: clueRide.Location;
+  location: Location;
   private editSegments = [
     'draft',
     'attraction',

--- a/src/pages/puzzle-modal/puzzle-modal.ts
+++ b/src/pages/puzzle-modal/puzzle-modal.ts
@@ -1,6 +1,6 @@
 import {Component} from "@angular/core";
 import {IonicPage, NavParams, ViewController} from "ionic-angular";
-import Puzzle = clueRide.Puzzle;
+import {Puzzle} from "../../providers/resources/puzzle/puzzle";
 
 /**
  * Generated class for the PuzzleModalPage page.

--- a/src/providers/lat-lon/lat-lon.ts
+++ b/src/providers/lat-lon/lat-lon.ts
@@ -1,0 +1,27 @@
+import {Injectable} from "@angular/core";
+
+/*
+  Generated class for the LatLonProvider provider.
+
+  See https://angular.io/guide/dependency-injection for more info on providers
+  and Angular DI.
+*/
+@Injectable()
+export class LatLonProvider {
+
+  constructor() {
+    return new LatLon;
+  }
+
+}
+
+/**
+ * How we place this on the Map.
+ */
+export class LatLon {
+  id: number;
+  // May want one of the geographical types understood by leaflet
+  lat: number;
+  lon: number;
+  lng: number;
+}

--- a/src/providers/move-start/move-start.ts
+++ b/src/providers/move-start/move-start.ts
@@ -4,7 +4,7 @@
 import {Injectable} from "@angular/core";
 import {Subject} from "rxjs/Subject";
 import {Geoposition} from "@ionic-native/geolocation";
-import LatLon = clueRide.LatLon;
+import {LatLon} from "../lat-lon/lat-lon";
 
 function buildGeoPositionFromLatLon(latLon: LatLon): Geoposition {
   return {

--- a/src/providers/resources/README.md
+++ b/src/providers/resources/README.md
@@ -56,8 +56,6 @@ _Modeled after examples in "Starter Guide" for http://ngx-restangular.com/ _
 
 - Created a separate service which is configured inside a 
 service.provider file.
-- Using a namespace to avoid name collisions (Location popped out as a 
-collision).
 - Currently, more than one class is defined in the location.ts file; 
 want to break these out.
 

--- a/src/providers/resources/image/image.ts
+++ b/src/providers/resources/image/image.ts
@@ -1,7 +1,8 @@
+import {Location} from "../location/location";
+
 /**
  * Created by jett on 11/5/17.
  */
-namespace clueRide {
 
   export class Image {
     lat: number;
@@ -9,7 +10,7 @@ namespace clueRide {
     locId: number;
     file: FormData;
 
-    public populateFromLocation(location: clueRide.Location) {
+    public populateFromLocation(location: Location) {
       this.locId = location.id;
       this.lat = location.latLon.lat;
       this.lon = location.latLon.lon;
@@ -21,4 +22,3 @@ namespace clueRide {
     }
 
   }
-}

--- a/src/providers/resources/location/location.ts
+++ b/src/providers/resources/location/location.ts
@@ -1,31 +1,23 @@
+import {LatLon} from "../../lat-lon/lat-lon";
+import {Injectable} from "@angular/core";
+
 /**
  * Created by jett on 7/10/17.
  */
-namespace clueRide {
-  export class Location {
+@Injectable()
+export class Location {
 
-    id: number;
-    nodeId: number;   // Provides Lat/Lon
-    latLon: LatLon;
-    name?: string;
-    description?: string;
-    locationGroupId?: number;
-    locationTypeName?: string;
-    locationTypeId: number;
-    featuredImageUrl?: string;
-    establishmentId?: number;
-    readinessLevel: string;
-  }
-
-  /**
-   * How we place this on the Map.
-   */
-  export class LatLon {
-    id: number;
-    // May want one of the geographical types understood by leaflet
-    lat: number;
-    lon: number;
-    lng: number;
-  }
-
+  id: number;
+  nodeId: number;   // Provides Lat/Lon
+  latLon: LatLon;
+  name?: string;
+  description?: string;
+  locationGroupId?: number;
+  locationTypeName?: string;
+  locationTypeId: number;
+  featuredImageUrl?: string;
+  establishmentId?: number;
+  readinessLevel: string;
 }
+
+

--- a/src/providers/resources/loctype/loctype.service.ts
+++ b/src/providers/resources/loctype/loctype.service.ts
@@ -1,6 +1,6 @@
 import {Inject, Injectable} from "@angular/core";
 import {LOCATION_TYPE_REST} from "./loctype.service.provider";
-import LocationType = clueRide.LocationType;
+import {LocationType} from "./loctype";
 /**
  * Created by jett on 7/22/17.
  */

--- a/src/providers/resources/loctype/loctype.spec.ts
+++ b/src/providers/resources/loctype/loctype.spec.ts
@@ -1,6 +1,6 @@
 import {LocationTypeService} from "./loctype.service";
 import {Subject} from "rxjs/Subject";
-import LocationType = clueRide.LocationType;
+import {LocationType} from "./loctype";
 /**
  * Created by jett on 10/29/17.
  */

--- a/src/providers/resources/loctype/loctype.ts
+++ b/src/providers/resources/loctype/loctype.ts
@@ -1,11 +1,9 @@
 /**
  * Created by jett on 10/8/17.
  */
-namespace clueRide {
-  export class LocationType {
-    id: number;
-    name: string;
-    description: string;
-    icon: string;
-  }
+export class LocationType {
+  id: number;
+  name: string;
+  description: string;
+  icon: string;
 }

--- a/src/providers/resources/puzzle/puzzle.ts
+++ b/src/providers/resources/puzzle/puzzle.ts
@@ -1,33 +1,30 @@
 /**
  * Created by jett on 10/24/17.
  */
-namespace clueRide {
-  /**
-   * Defines properties of a Puzzle.
-   * Many-to-one per Location
-   */
-  export class Puzzle {
-    id: number;
-    name: string;
-    locationName: string;
-    question: string;
-    answers: Array<Answer>;
-    correctAnswer: AnswerKey;
-    points: number;
-  }
+/**
+ * Defines properties of a Puzzle.
+ * Many-to-one per Location
+ */
+export class Puzzle {
+  id: number;
+  name: string;
+  locationName: string;
+  question: string;
+  answers: Array<Answer>;
+  correctAnswer: AnswerKey;
+  points: number;
+}
 
-  export class Answer {
-    id: number;
-    // puzzleId: number;
-    answerKey: AnswerKey;
-    answer: string;
-  }
+export class Answer {
+  id: number;
+  // puzzleId: number;
+  answerKey: AnswerKey;
+  answer: string;
+}
 
-  /**
-   * Possible answer keys.
-   */
-  export enum AnswerKey {
-    A, B, C, D, E
-  }
-
+/**
+ * Possible answer keys.
+ */
+export enum AnswerKey {
+  A, B, C, D, E
 }

--- a/src/tsconfig.test.json
+++ b/src/tsconfig.test.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": "",
+    "paths": {
+      "front-end-common": ["../../front-end-common/index"]
+    },
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
- Removes occurrences of `namespace` and re-imports as required.

When running the `ng test`, I found that the `front-end-common` module
had not been placed within the `tsconfig.test.json` config for that path
to be recognized. This is corrected in this commit as well.