### PR TITLE
LE: Feb 2019 Cleanup

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,7 +19,7 @@ import {MarkersComponent} from "../components/markers/markers";
 import {Resource} from "../providers/resources/resource";
 import {LocEditPageModule} from "../pages/loc-edit/loc-edit.module";
 import {MapComponentModule} from "../components/map/map.module";
-import {MapMoveService} from "../providers/map-move/map-move";
+import {MapDragService} from "../providers/map-drag/map-drag";
 
 @NgModule({
   declarations: [
@@ -47,7 +47,7 @@ import {MapMoveService} from "../providers/map-move/map-move";
   ],
   providers: [
     MarkersComponent,
-    MapMoveService,
+    MapDragService,
     Resource,
     StatusBar,
     SplashScreen,

--- a/src/components/add-loc-button/add-loc-button.html
+++ b/src/components/add-loc-button/add-loc-button.html
@@ -1,6 +1,6 @@
 <!-- Generated template for the AddLocButtonComponent component -->
 <ion-fab right bottom>
-  <button ion-fab mini (tap)="addLocationAction()">
+  <button ion-fab mini (tap)="addLocationAction($event)">
     <ion-icon name="add"></ion-icon>
   </button>
 </ion-fab>

--- a/src/components/add-loc-button/add-loc-button.ts
+++ b/src/components/add-loc-button/add-loc-button.ts
@@ -24,9 +24,10 @@ export class AddLocButtonComponent {
     console.log('Hello AddLocButtonComponent Component');
   }
 
-  addLocationAction() {
+  addLocationAction(event) {
+    event.srcEvent.stopPropagation();
     const newGeoposition: Geoposition = this.mapCenter.getValue();
-    console.log(newGeoposition.coords);
+    alert(JSON.stringify(newGeoposition.coords));
     let newLatLon = new LatLon();
     newLatLon.lat = newGeoposition.coords.latitude;
     newLatLon.lon = newGeoposition.coords.longitude;

--- a/src/components/heading/heading.ts
+++ b/src/components/heading/heading.ts
@@ -178,6 +178,7 @@ export class HeadingComponent {
    * reflect the orientation of the marker as well.
    * @param coordinates
    */
+  // TODO: Not clear we need each of these type definitions. We do need to accept something with marker heading or not.
   public updateLocation(coordinates: string | L.Point | Coordinates) {
     console.log("Heading.updateLocation() invoked");
     /* While updating the location of the marker ... */

--- a/src/components/map/map.html
+++ b/src/components/map/map.html
@@ -2,21 +2,21 @@
 <div class="map-content crosshairs" id="map">
 
   <ion-fab right top>
-    <button ion-fab mini (tap)="settingsFabAction()">
+    <button ion-fab mini (tap)="settingsFabAction($event)">
       <ion-icon name="settings"></ion-icon>
     </button>
     <ion-fab-list>
 
       <div class="labeledFab">
         <ion-label>Toggle Lat/Lon</ion-label>
-        <button ion-fab (click)="settingsToggleLatLon()">
+        <button ion-fab (tap)="settingsToggleLatLon($event)">
           <ion-icon name="checkmark"></ion-icon>
         </button>
       </div>
 
       <div class="labeledFab">
         <ion-label>Toggle Auto-center</ion-label>
-        <button ion-fab (click)="settingsToggleAutoCenter()">
+        <button ion-fab (tap)="settingsToggleAutoCenter($event)">
           <ion-icon name="locate"></ion-icon>
         </button>
       </div>

--- a/src/components/map/map.ts
+++ b/src/components/map/map.ts
@@ -1,18 +1,18 @@
+import {App} from "ionic-angular";
+import {AuthService, GeoLocService, LatLon, ObservableGeoposition} from "front-end-common";
+import {BehaviorSubject} from "rxjs/BehaviorSubject";
 import {Component, Injectable} from "@angular/core";
+import {CRMarker} from "../markers/crMarker";
 import {isDefined} from "ionic-angular/util/util";
 import {MarkersComponent} from "../markers/markers";
-import {SplashScreen} from "@ionic-native/splash-screen";
-import {AuthService, GeoLocService, LatLon, ObservableGeoposition} from "front-end-common";
 import {Geoposition} from "@ionic-native/geolocation";
+import {HeadingComponent} from "../heading/heading";
 import * as L from "leaflet";
-import {CRMarker} from "../markers/crMarker";
 import {Location} from "../../providers/resources/location/location";
 import {LocEditPage} from "../../pages/loc-edit/loc-edit";
-import {App} from "ionic-angular";
 import {LatLonComponent} from "../lat-lon/lat-lon";
-import {HeadingComponent} from "../heading/heading";
-import {MapMoveService} from "../../providers/map-move/map-move";
-import {BehaviorSubject} from "rxjs/BehaviorSubject";
+import {MapDragService} from "src/providers/map-drag/map-drag";
+import {SplashScreen} from "@ionic-native/splash-screen";
 
 interface LocationMap {
   [index: number]: Location;
@@ -33,12 +33,14 @@ export class MapComponent {
 
   /** Holds the current zoom for the map. */
   zoomLevel: number;
-  public static map: any;
-  static locationMap: LocationMap = {};
   showLatLon: boolean = true;
   showCrosshairs: boolean = false;
-  static latLon: LatLonComponent = <any>{};
+
+  /* TODO: Move to a service. */
+  public static map: any;
+  static locationMap: LocationMap = {};
   private static tethered: boolean = false;
+  static latLon: LatLonComponent = <any>{};
   private static reportedPosition: BehaviorSubject<Geoposition> = new BehaviorSubject({
     coords: {
       latitude: 33.75,
@@ -59,7 +61,7 @@ export class MapComponent {
     public geoLoc: GeoLocService,
     private heading: HeadingComponent,
     private markers: MarkersComponent,
-    private moveStart: MapMoveService,
+    private mapDragService: MapDragService,
     public splashScreen: SplashScreen,
   ) {
     this.zoomLevel = 14;
@@ -85,12 +87,14 @@ export class MapComponent {
       MapComponent.locationMap = {};
       MapComponent.map = L.map('map');
       MapComponent.map.setView(leafletPosition, this.zoomLevel);
+
+      /* TODO: Rename this presentation component. */
       MapComponent.latLon = new LatLonComponent();
       MapComponent.latLon.addTo(MapComponent.map);
       MapComponent.latLon.setPositionSubject(MapComponent.reportedPosition);
 
       /* Attach the reported position subject to the Move Start service. */
-      this.moveStart.useMap(MapComponent.map, MapComponent.reportedPosition);
+      this.mapDragService.useMap(MapComponent.map, MapComponent.reportedPosition);
     }
 
 
@@ -105,7 +109,7 @@ export class MapComponent {
 
     /* Turn off auto-center if user drags the map. */
     MapComponent.map.on('movestart', () => {
-      this.moveStart.setAutoCenter(false);
+      this.mapDragService.setAutoCenter(false);
     });
 
     /* Begin paying attention to position changes. */
@@ -122,19 +126,23 @@ export class MapComponent {
     let positionObservable = this.geoLoc.getPositionWatch();
     positionObservable.subscribe(
       (position) => {
-        this.updatePosition(position);
+        if (!this.mapDragService.isDragInProgress()) {
+          this.setNewCenterForMap(position);
+        }
       }
     );
     return positionObservable;
   }
 
-  updatePosition(position: Geoposition) {
+  setNewCenterForMap(position: Geoposition) {
     this.heading.updateLocation(position.coords);
 
     /* Move map so current location is centered. */
-    if (this.moveStart.isAutoCenter() && MapComponent.map) {
-      /* Suspend move event generation */
+    if (this.mapDragService.isAutoCenter() && MapComponent.map) {
+
+      /* Suspend move event generation. */
       MapComponent.map.off('movestart');
+
       // TODO: LE-70 Prepare a better pattern for converting between these two representations.
       let latLon: LatLon = {
         id: 0,
@@ -145,9 +153,11 @@ export class MapComponent {
       MapComponent.map.panTo(latLon);
       console.log("Map.updatePosition: next Reported Position");
       MapComponent.reportedPosition.next(position);
+
+      /* Restore move event generation. */
       MapComponent.map.on('movestart',
         () => {
-          this.moveStart.setAutoCenter(false);
+          this.mapDragService.setAutoCenter(false);
         }
       );
     }
@@ -205,27 +215,44 @@ export class MapComponent {
     }
   }
 
-  settingsFabAction() {
+  settingsFabAction(event) {
+    event.srcEvent.stopPropagation();
     console.log("Settings Toggle");
   }
 
-  settingsToggleCrosshairs() {
+  settingsToggleCrosshairs(event) {
+    event.srcEvent.stopPropagation();
     this.showCrosshairs = !this.showCrosshairs;
     console.log("Crosshairs: " + this.showCrosshairs);
   }
 
-  settingsToggleLatLon() {
+  settingsToggleLatLon(event) {
+    event.srcEvent.stopPropagation();
     this.showLatLon = !this.showLatLon;
     MapComponent.latLon.enableDisplay(this.showLatLon);
     console.log("Lat/Lon: " + this.showLatLon);
   }
 
-  settingsToggleAutoCenter() {
-    this.moveStart.setAutoCenter(!this.moveStart.isAutoCenter());
+  settingsToggleAutoCenter(event) {
+    event.srcEvent.stopPropagation();
+    this.mapDragService.setAutoCenter(!this.mapDragService.isAutoCenter());
   }
 
+  /* Won't be appropriate for Loc Edit. */
   settingsToggleTether() {
     MapComponent.tethered = !MapComponent.tethered;
+  }
+
+  /* Life-cycle of watch */
+  ionViewWillLeave() {
+    this.geoLoc.clearWatch();
+  }
+
+  /* Life-cycle of watch */
+  ionViewWillEnter() {
+    if (MapComponent.map) {
+      this.setWatch();
+    }
   }
 
 }

--- a/src/pages/image-capture/image-capture.html
+++ b/src/pages/image-capture/image-capture.html
@@ -28,7 +28,7 @@
         </ion-slide>
       </ion-slides>
       <ion-buttons>
-        <button class="button-inner"
+        <button ion-button round
                 (click)="save()">
           Save as new Image
         </button>
@@ -38,7 +38,7 @@
     <div *ngIf="!haveImagesToShow()">
       No images yet.
       <ion-buttons>
-        <button class="button-inner"
+        <button ion-button round
                 (click)="fakeImage()">
           Save fake Image
         </button>

--- a/src/providers/map-drag/map-drag.ts
+++ b/src/providers/map-drag/map-drag.ts
@@ -22,13 +22,16 @@ function buildGeoPositionFromLatLon(latLon: LatLon): Geoposition {
 }
 
 @Injectable()
-export class MapMoveService {
+export class MapDragService {
 
+  /** Set to true if the center of the map should follow either Device or Tether instead of Drag. */
   private autoCenterFlag: boolean = true;
   private mapInstance: any;
   private centerSubject: BehaviorSubject<Geoposition>;
+  private dragInProgress: boolean = false;
 
   constructor (
+    /* Currently no dependencies. */
   ) {
   }
 
@@ -49,18 +52,23 @@ export class MapMoveService {
     this.centerSubject = centerSubject;
 
     map.on("movestart", () => {
+      this.dragInProgress = true;
       this.setAutoCenter(false);
     });
 
     map.on("moveend", () => {
-      if (!this.isAutoCenter()) {
-        this.updateCenterSubject(map.getCenter());
-      }
+      this.sendDragEndLocation(map.getCenter());
+      this.dragInProgress = false;
     });
 
   }
 
-  updateCenterSubject(latLon: LatLon) {
+  isDragInProgress(): boolean {
+    return this.dragInProgress;
+  }
+
+  sendDragEndLocation(latLon: LatLon) {
+    console.log("Setting new map center from Map Drag");
     this.centerSubject.next(
       buildGeoPositionFromLatLon(
         latLon


### PR DESCRIPTION
- Renames MapDragService to reflect what happens when the map is dragged.
- Turns buttons into the Round ones (save image was difficult).
- Renames generation of Drag End event to sendDragEndLocation().
- Adds life-cycle events to the position watch.
- Stops propagation of tap events for the FAB buttons.