### PR TITLE
LE-102 Tie "Use this Email" to the status page's flow

### DIFF
--- a/src/pages/status/status.html
+++ b/src/pages/status/status.html
@@ -24,7 +24,7 @@
     Registration Status: {{appState.registrationState}}
   </div>
   <div>
-    Registered as: {{appState.registeredAs}}
+    Registered as: {{profile.getPrincipal()}}
   </div>
   <div *ngIf="appState.isRunningBrowser">
     Running against Browser (non-native)

--- a/src/pages/status/status.ts
+++ b/src/pages/status/status.ts
@@ -1,15 +1,12 @@
+import {AppState} from "../../providers/app-state/app-state";
+import {AppStateService} from "../../providers/app-state/app-state.service";
 import {Component} from '@angular/core';
 import {IonicPage, NavController, NavParams} from 'ionic-angular';
-import {AppStateService} from "../../providers/app-state/app-state.service";
-import {AppState} from "../../providers/app-state/app-state";
+import {ProfileService} from "front-end-common";
 
 /**
- * Generated class for the StatusPage page.
- *
- * See https://ionicframework.com/docs/components/#navigation for more info on
- * Ionic pages and navigation.
+ * Presentation of the properties carried by the App State service.
  */
-
 @IonicPage()
 @Component({
   selector: 'page-status',
@@ -23,6 +20,7 @@ export class StatusPage {
     public navCtrl: NavController,
     public navParams: NavParams,
     private appStateService: AppStateService,
+    public profile: ProfileService,
   ) {
     this.appState = this.appStateService.getAppState();
   }

--- a/src/providers/app-state/app-state.service.ts
+++ b/src/providers/app-state/app-state.service.ts
@@ -1,6 +1,14 @@
 import {Injectable} from '@angular/core';
 import {AppState} from "./app-state";
-import {AuthService, AuthState, GeoLocService, PlatformStateService, RegistrationPage} from "front-end-common";
+import {
+  AuthService,
+  AuthState,
+  GeoLocService,
+  PlatformStateService,
+  ProfileConfirmationService,
+  ProfileService,
+  RegistrationPage
+} from "front-end-common";
 import {App, NavController, Platform} from "ionic-angular";
 import {HomePage} from "../../pages/home/home";
 import {MapDataService} from "../map-data/map-data";
@@ -26,6 +34,8 @@ export class AppStateService {
     private geoLoc: GeoLocService,
     private mapDataService: MapDataService,
     public platformStateService: PlatformStateService,
+    public profileService: ProfileService,
+    private profileConfirmationService: ProfileConfirmationService,
     public splashScreen: SplashScreen,
   ) {
     console.log('Hello AppStateService Provider');
@@ -127,7 +137,26 @@ export class AppStateService {
   private choosePage = (authState: AuthState): void => {
     this.nav.setRoot(StatusPage);
     if (authState === AuthState.UNREGISTERED) {
-        this.nav.push(RegistrationPage);
+      this.nav.push(RegistrationPage);
+      /* Hook into notification that selected email has been confirmed. */
+      this.profileConfirmationService.confirmationState$.subscribe(
+        (confirmationState) => {
+
+          if (confirmationState.confirmed) {
+            console.log("Accepting the given email");
+            this.recordRegistrationState(AuthState.REGISTERED);
+            this.nav.pop()
+              .then(
+                () => this.nav.pop()
+              )
+              .catch(
+                () => console.log("Problem Popping out of Confirmation Page")
+              );
+          } else {
+            console.log("Choosing a different email");
+          }
+        }
+      );
     }
   };
 
@@ -136,9 +165,9 @@ export class AppStateService {
     if (authState === AuthState.REGISTERED) {
       console.log("Registered and ready for action");
       this.appState.registeredAs = 'REGISTERED';
-      // TODO: Put the profile lookup here so we can report who has registered this device.
+      this.profileService.loadMemberProfile();
     }
 
-  }
+  };
 
 }


### PR DESCRIPTION
- Sets up paying attention to the Confirmation State to know when we
can proceed after setting up registration.

Response includes popping out of Confirmation and Registration pages.

Now that I see this, we may not need to have the separate apps know
about this. They could setup the page that we want to serve as the "Home"
page and then let the FEC get us back to that page.